### PR TITLE
Fix link to production site in dev process section

### DIFF
--- a/PROJECT-BRIEF.md
+++ b/PROJECT-BRIEF.md
@@ -148,7 +148,7 @@ When you and your pair partner have working code that you believe is ready to be
 3. Incorporate feedback from the other pair team into your work until both you and they are satisfied the code is ready to be merged.
 4. Request that one of the mentors review the PR for final approval.
 5. Once approved, merge the PR into `main`. (Your code will be built and deployed to production automatically thanks to [Netlify](https://www.netlify.com/).)
-6. Check your work on the [production site]({link to cohort live site}).
+6. Check your work on the [production site](https://tcl-9-smart-shopping-list.netlify.app/).
 7. Celebrate! 🥳
 
 ### Slack


### PR DESCRIPTION
## Description

On the kick off call, I noticed that the link to the production site in the "Development Process" section hadn't been updated. This PR fixes the link.

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓  | :bug: Bug fix              |
|   | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

### Before

![](https://user-images.githubusercontent.com/4306/89132218-74b7bb80-d4c7-11ea-8254-6d79935cd108.png)

Raw Markup for the link, but it's not an actual link

### After

![](https://user-images.githubusercontent.com/4306/89132251-b5afd000-d4c7-11ea-99b4-8b78a50321b5.png)

"production site" is linked to the team's production site

## Testing Steps / QA Criteria

Click the link to ensure it goes to the correct production site.